### PR TITLE
update translation in welcome mail

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.9.2 (unreleased)
 ------------------
 
+- Fix Translation in Welcome mail.
+  [tschanzt]
+
 - Improve translations.
   [mbaechtold]
 

--- a/ftw/usermanagement/locales/de/LC_MESSAGES/ftw.usermanagement.po
+++ b/ftw/usermanagement/locales/de/LC_MESSAGES/ftw.usermanagement.po
@@ -269,7 +269,7 @@ msgid "text_usermanagemnt_mail_user_text"
 msgstr "Sie wurden auf der Plattform ${site_title} registriert"
 
 msgid "usermanagement_mail_notification_subject"
-msgstr "Wilkommen auf ${title}"
+msgstr "Willkommen auf ${title}"
 
 #. Default: "Users Management"
 #: ./ftw/usermanagement/profiles/default/actions.xml


### PR DESCRIPTION
@fguyer @maethu this pr fixes a typo in the mail sent when we send a user his login data