### PR TITLE
fix change-password url in mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix change-password url in mails to point to Plone's form. [jone]
 
 
 1.9.3 (2015-09-04)

--- a/ftw/usermanagement/browser/user/user_notify.py
+++ b/ftw/usermanagement/browser/user/user_notify.py
@@ -122,9 +122,8 @@ class UserNotify(BrowserView):
         """ Return a map with all required infos for the mail template
         """
         mtool = getToolByName(self, 'portal_membership')
-        pwresettool = getToolByName(self, 'portal_password_reset')
+        portal_url = getToolByName(self, 'portal_url')
         member = mtool.getMemberById(userid)
-
         homefolder = mtool.getHomeFolder(userid)
 
         if not member:
@@ -137,7 +136,7 @@ class UserNotify(BrowserView):
         options['fullname'] = member.getProperty('fullname', member.id)
         options['homefolder'] = \
             homefolder.absolute_url() if homefolder else None
-        options['pw_reset_url'] = pwresettool.absolute_url()
+        options['pw_reset_url'] = portal_url() + '/@@change-password'
         options['site_title'] = self._get_site_title()
         options['contact_email'] = self._get_contact_email()
         options['pw'] = reset_pw and self.reset_password(member) or None

--- a/ftw/usermanagement/tests/test_unit_user_notify.py
+++ b/ftw/usermanagement/tests/test_unit_user_notify.py
@@ -30,13 +30,13 @@ class GetOptionsTests(MockTestCase):
 
         self.mtool = self.mocker.mock(count=False)
         self.mock_tool(self.mtool, 'portal_membership')
-        self.mock_tool(self.mtool, 'portal_password_reset')
         self.expect(self.mtool.getHomeFolder(ANY)).result(self.context)
         self.expect(self.context.absolute_url()).result('http://nowhere/')
         self.expect(self.mtool.absolute_url()).result('http://nowhere/')
 
         self.urltool = self.mocker.mock(count=False)
         self.mock_tool(self.urltool, 'portal_url')
+        self.expect(self.urltool()).result('http://nohost/plone')
         self.expect(
             self.urltool.getPortalObject().Title()).result('Pörtal Title')
 
@@ -69,6 +69,7 @@ class GetOptionsTests(MockTestCase):
         self.assertEquals(result['contact_email'], 'contact@test.ch')
         self.assertEquals(result['pw'], None)
         self.assertEquals(result['reset_pw'], False)
+        self.assertEquals(result['pw_reset_url'], 'http://nohost/plone/@@change-password')
 
     def test_with_member_and_pw_reset(self):
 
@@ -85,6 +86,7 @@ class GetOptionsTests(MockTestCase):
         self.assertEquals(result['contact_email'], 'contact@test.ch')
         self.assertEquals(result['pw'], '12345')
         self.assertEquals(result['reset_pw'], True)
+        self.assertEquals(result['pw_reset_url'], 'http://nohost/plone/@@change-password')
 
 
 class ResetPasswordTests(MockTestCase):


### PR DESCRIPTION
The old url ("/portal_password_reset") did not point to a form in recent Plone versions.
The new url ("/@@change-password") is Plone's standard password changing form.