### PR TITLE
Drop support for Plone 4.1.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,6 @@ recipe to manage your project, you can do this:
 Compatibility
 =============
 
-Plone 4.1
-
-.. image:: https://jenkins.4teamwork.ch/job/ftw.usermanagement-master-test-plone-4.1.x.cfg/badge/icon
-   :target: https://jenkins.4teamwork.ch/job/ftw.usermanagement-master-test-plone-4.1.x.cfg
-
 Plone 4.2
 
 .. image:: https://jenkins.4teamwork.ch/job/ftw.usermanagement-master-test-plone-4.2.x.cfg/badge/icon

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.9.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Plone 4.1 because the dependency `ftw.tabbedview` has
+  dropped support for Plone 4.1 too. [mbaechtold]
 
 
 1.9.4 (2016-02-23)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='ftw.usermanagement',
 
       classifiers=[
           'Framework :: Plone',
-          'Framework :: Plone :: 4.1',
           'Framework :: Plone :: 4.2',
           'Framework :: Plone :: 4.3',
           'Programming Language :: Python',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    sources.cfg
-
-package-name = ftw.usermanagement


### PR DESCRIPTION
This is needed because the dependency "ftw.tabbedview" has dropped support for Plone 4.1 too. See https://github.com/4teamwork/ftw.tabbedview/pull/52/commits for more information.