### PR TITLE
Add user export script

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.9.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a basic user export to the @@user_management`-view.
+  It exports all member properties and the assigned groups of the users.
+  [elioschmutz]
 
 
 1.9.5 (2016-10-20)

--- a/ftw/usermanagement/browser/js/user_group.js
+++ b/ftw/usermanagement/browser/js/user_group.js
@@ -5,6 +5,7 @@ $(function(){
           initUserOverlay();
           editUser();
           deleteUsers();
+          exportUsers();
           notifyUsers();
           notifyUsersPassword();
           addUser();
@@ -118,6 +119,15 @@ $(function(){
             var $form = $('form[name="add_member_form"]').serializeArray();
             var url = (window.portal_url + "/user_register");
             jquery_post_request(url, $form);
+       });
+   }
+
+   function exportUsers(){
+       $('div#users_management_overview input[name="export.users"]').bind('click', function(e,o){
+           // add a new user
+            e.preventDefault();
+            var url = (window.portal_url + "/users_export");
+            window.location.replace(url);
        });
    }
 

--- a/ftw/usermanagement/browser/user/configure.zcml
+++ b/ftw/usermanagement/browser/user/configure.zcml
@@ -49,5 +49,12 @@
         permission="zope2.ManageUsers"
         />
 
+    <browser:page
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        name="users_export"
+        class=".user_export.UserExport"
+        permission="zope2.ManageUsers"
+        />
+
 
 </configure>

--- a/ftw/usermanagement/browser/user/user_export.py
+++ b/ftw/usermanagement/browser/user/user_export.py
@@ -1,0 +1,106 @@
+from DateTime import DateTime
+from datetime import datetime
+from ftw.usermanagement.browser.user.users import UsersSearchResultExecutor
+from plone import api
+from StringIO import StringIO
+from xlsxwriter.workbook import Workbook
+
+
+class UserExport(object):
+
+    filename = 'member_export.xlsx'
+    contenttype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+    blacklist_attribute_names = [
+        'visible_ids',
+        'wysiwyg_editor',
+        'error_log_update',
+        'listed',
+        'language',
+        'portal_skin',
+        'ext_editor',
+        'last_login_time',
+    ]
+
+    additional_attribute_names = [
+        'groups'
+    ]
+
+    def __call__(self):
+        self.request.response.setHeader("Content-type", self.contenttype)
+        self.request.response.setHeader(
+            "Content-Disposition", 'inline; filename="%s"' % self.filename)
+        return self.export()
+
+    def export(self):
+        output = StringIO()
+
+        workbook = Workbook(output)
+        default_format = workbook.add_format()
+        datetime_format = workbook.add_format({'num_format': 'dd.mm.yyyy hh:mm'})
+
+        worksheet = workbook.add_worksheet('User export')
+        worksheet.write_row(0, 0, self.attribute_names)
+
+        users = api.user.get_users()
+        for row, user in enumerate(users):
+            for column, prop in enumerate(self.attribute_names):
+                value = user.getProperty(prop, '')
+                cell_format = default_format
+
+                if isinstance(value, DateTime):
+                    value = value.asdatetime()
+
+                if isinstance(value, datetime):
+                    value = value.replace(tzinfo=None)
+                    cell_format = datetime_format
+
+                if prop == 'groups':
+                    value = self._get_groups_of_user(user)
+
+                worksheet.write(
+                    row+1, column, self._decode_string(value), cell_format)
+
+        if users:
+            worksheet.autofilter(0, 0, len(users)+1, len(self.attribute_names))
+
+        workbook.close()
+
+        output.seek(0)
+        return output.read()
+
+    @property
+    def attribute_names(self):
+        """Returns the attribute names which should be exported.
+        """
+        if not hasattr(self, '_attribute_names'):
+            attribute_names = self._get_member_data_propertie_names()
+            attribute_names.extend(self.additional_attribute_names)
+            attribute_names = list(set(attribute_names) - set(self.blacklist_attribute_names))
+            setattr(self, '_attribute_names', attribute_names)
+
+        return getattr(self, '_attribute_names')
+
+    def _decode_string(self, value):
+        if isinstance(value, str):
+            return value.decode('utf-8')
+        return value
+
+    def _get_user_search_result_executor(self):
+        if not hasattr(self, '_user_search_result_executor'):
+            setattr(self, '_user_search_result_executor',
+                    UsersSearchResultExecutor(
+                        self.context, query=None, is_email_login=None)
+                    )
+        return getattr(self, '_user_search_result_executor')
+
+    def _get_groups_of_user(self, user):
+        """ Return all groupnames of a user as a string
+        If we have no groups, we return a translated info string.
+        """
+        return self._get_user_search_result_executor().get_group_names_of_user(
+            user.getId())
+
+    def _get_member_data_propertie_names(self):
+        memberdata = api.portal.get_tool('portal_memberdata')
+        return memberdata.propdict().keys()

--- a/ftw/usermanagement/browser/user/users.pt
+++ b/ftw/usermanagement/browser/user/users.pt
@@ -74,6 +74,7 @@
           <input type="submit" name="notify.users" value="Notify user" i18n:attributes="value" />
           <input type="submit" name="notify.users.password" value="Notify user and reset password" i18n:attributes="value" />
           <input class="allowMultiSubmit" type="submit" name="delete.users" value="Delete user" i18n:attributes="value" />
+          <input type="submit" name="export.users" value="Export users" i18n:attributes="value" />
         </div>
         <tal:END_CUSTOM_____________________________________ />
 

--- a/ftw/usermanagement/locales/de/LC_MESSAGES/ftw.usermanagement.po
+++ b/ftw/usermanagement/locales/de/LC_MESSAGES/ftw.usermanagement.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-30 09:40+0000\n"
+"POT-Creation-Date: 2016-10-24 09:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,6 +57,10 @@ msgstr "Benutzer löschen"
 #: ./ftw/usermanagement/browser/user/users.pt:25
 msgid "Email"
 msgstr "E-Mail"
+
+#: ./ftw/usermanagement/browser/user/users.pt:77
+msgid "Export users"
+msgstr "Benutzer exportieren"
 
 #: ./ftw/usermanagement/browser/user/users.pt:23
 msgid "Firstname"

--- a/ftw/usermanagement/locales/en/LC_MESSAGES/ftw.usermanagement.po
+++ b/ftw/usermanagement/locales/en/LC_MESSAGES/ftw.usermanagement.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-30 09:40+0000\n"
+"POT-Creation-Date: 2016-10-24 09:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,6 +59,10 @@ msgstr ""
 
 #: ./ftw/usermanagement/browser/user/users.pt:25
 msgid "Email"
+msgstr ""
+
+#: ./ftw/usermanagement/browser/user/users.pt:77
+msgid "Export users"
 msgstr ""
 
 #: ./ftw/usermanagement/browser/user/users.pt:23

--- a/ftw/usermanagement/locales/fr/LC_MESSAGES/ftw.usermanagement.po
+++ b/ftw/usermanagement/locales/fr/LC_MESSAGES/ftw.usermanagement.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-30 09:40+0000\n"
+"POT-Creation-Date: 2016-10-24 09:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,6 +57,10 @@ msgstr "Supprimer utilisateur(s)"
 #: ./ftw/usermanagement/browser/user/users.pt:25
 msgid "Email"
 msgstr "Email"
+
+#: ./ftw/usermanagement/browser/user/users.pt:77
+msgid "Export users"
+msgstr "Exportation d'utilisateur"
 
 #: ./ftw/usermanagement/browser/user/users.pt:23
 msgid "Firstname"

--- a/ftw/usermanagement/locales/ftw.usermanagement.pot
+++ b/ftw/usermanagement/locales/ftw.usermanagement.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-30 09:40+0000\n"
+"POT-Creation-Date: 2016-10-24 09:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,6 +56,10 @@ msgstr ""
 
 #: ./ftw/usermanagement/browser/user/users.pt:25
 msgid "Email"
+msgstr ""
+
+#: ./ftw/usermanagement/browser/user/users.pt:77
+msgid "Export users"
 msgstr ""
 
 #: ./ftw/usermanagement/browser/user/users.pt:23

--- a/ftw/usermanagement/tests/__init__.py
+++ b/ftw/usermanagement/tests/__init__.py
@@ -10,6 +10,7 @@ class FunctionalTestCase(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.request = self.layer['request']
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))

--- a/ftw/usermanagement/tests/test_user_export.py
+++ b/ftw/usermanagement/tests/test_user_export.py
@@ -1,0 +1,90 @@
+from DateTime import DateTime
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.usermanagement.tests import FunctionalTestCase
+from openpyxl import load_workbook
+from StringIO import StringIO
+from zope.component import getMultiAdapter
+
+
+class TestExportUsers(FunctionalTestCase):
+
+    def test_decode_string_returns_unicode_string_if_utf_8(self):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+        self.assertEqual(
+            u'James B\xf6nd',
+            view._decode_string('James B\xc3\xb6nd'))
+
+    def test_decode_string_returns_unicode_string_if_unicode(self):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+        self.assertEqual(
+            u'James B\xf6nd',
+            view._decode_string(u'James B\xf6nd'))
+
+    def test_decode_string_returns_value_if_no_string(self):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+
+        dummy_obj = object()
+
+        self.assertEqual(
+            dummy_obj,
+            view._decode_string(dummy_obj))
+
+    def test_attribute_names_including_additional_attributes(self):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+
+        for attributename in view.additional_attribute_names:
+            self.assertIn(
+                attributename,
+                view.attribute_names)
+
+    def test_attribute_names_excluding_blacklist_attributes(self):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+
+        for attributename in view.blacklist_attribute_names:
+            self.assertNotIn(
+                attributename,
+                view.attribute_names)
+
+    @browsing
+    def test_validate_exported_xlsx_data(self, browser):
+        self.grant('Manager')
+        view = getMultiAdapter((self.portal, self.request), name='users_export')
+
+        create(Builder('user')
+               .named('Chuck', 'Norris')
+               .in_groups('Administrators', 'Reviewers')
+               .having(
+                   home_page='http://www.test.ch',
+                   location='Earth',
+                   email='chuck.norris@test.ch',
+                   description='Dangerous',
+                   login_time=DateTime("30.12.2016 16:30")
+                   ))
+
+        wb = load_workbook(StringIO(view.export()), read_only=True)
+        ws = wb.get_active_sheet()
+
+        self.assertEqual(
+            [u'description', u'home_page', u'location', u'groups', u'fullname', u'email', u'login_time'],
+            [cell.value for cell in ws.rows.next()],
+            "Some header rows are incorrect. Please check the output."
+            )
+
+        self.assertEqual(
+            [u'Dangerous',
+             u'http://www.test.ch',
+             u'Earth',
+             u'Administrators, Reviewers',
+             u'Norris Chuck',
+             u'chuck.norris@test.ch',
+             datetime(2016, 12, 30, 16, 30)],
+            [cell.value for cell in ws.rows.next()],
+            "Some user values are incorrect. Please check the output")

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'ftw.table',
     'ftw.testbrowser',
     'ftw.testing',
+    'openpyxl',
     'plone.app.testing',
     'plone.testing',
     ]
@@ -50,7 +51,9 @@ setup(name='ftw.usermanagement',
           'ftw.table',
           'ftw.upgrade >= 1.11.0',  # upgrade-step:directory support
           'plone.principalsource',
+          'plone.api',
           'setuptools',
+          'xlsxwriter',
           ],
 
       tests_require=tests_require,


### PR DESCRIPTION
This PR will add a basic user export to the `@@user_management``-view.

It exports all member properties and the assigned groups of the users.

![bildschirmfoto 2016-10-24 um 12 29 02](https://cloud.githubusercontent.com/assets/557005/19644263/15132d70-99ef-11e6-884b-ddd7a62f7161.png)
