### PR TITLE
Use newer version of "six".

### DIFF
--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -12,3 +12,4 @@ package-name = ftw.usermanagement
 ; lesser than 38.7.0), it is not used in the development / test environment, due to the change
 ; https://github.com/4teamwork/ftw-buildouts/pull/136 in our buildout setup.
 plone.recipe.zope2instance = 4.4.1
+six = 1.12.0


### PR DESCRIPTION
The current release of six (1.4.1) is pinned in https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg which makes the test setup fail because more recent releases of `ftw.upgrade` make use of `six.ensure_text` which was only added in six 1.12.0.

This may be removed when https://github.com/4teamwork/ftw.upgrade/issues/198 has been solved.